### PR TITLE
Check for empty tags and return sensible defaults

### DIFF
--- a/src/ao3/works.py
+++ b/src/ao3/works.py
@@ -111,7 +111,7 @@ class Work(object):
         blockquote = summary_div.find('blockquote')
         return blockquote.renderContents().decode('utf8').strip()
 
-    def _lookup_stat(self, class_name):
+    def _lookup_stat(self, class_name, default=None):
         """Returns the value of a stat."""
         # The stats are stored in a series of divs of the form
         #
@@ -120,6 +120,8 @@ class Work(object):
         # This is a convenience method for looking up values from these divs.
         #
         dd_tag = self._soup.find('dd', attrs={'class': class_name})
+        if dd_tag is None:
+            return default
         if 'tags' in dd_tag.attrs['class']:
             return self._lookup_list_stat(dd_tag=dd_tag)
         return dd_tag.contents[0]
@@ -149,12 +151,12 @@ class Work(object):
     @property
     def rating(self):
         """The age rating for this work."""
-        return self._lookup_stat('rating')
+        return self._lookup_stat('rating', [])
 
     @property
     def warnings(self):
         """Any archive warnings on the work."""
-        value = self._lookup_stat('warning')
+        value = self._lookup_stat('warning', [])
         if value == ['No Archive Warnings Apply']:
             return []
         else:
@@ -163,32 +165,32 @@ class Work(object):
     @property
     def category(self):
         """The category of the work."""
-        return self._lookup_stat('category')
+        return self._lookup_stat('category', [])
 
     @property
     def fandoms(self):
         """The fandoms in this work."""
-        return self._lookup_stat('fandom')
+        return self._lookup_stat('fandom', [])
 
     @property
     def relationship(self):
         """The relationships in this work."""
-        return self._lookup_stat('relationship')
+        return self._lookup_stat('relationship', [])
 
     @property
     def characters(self):
         """The characters in this work."""
-        return self._lookup_stat('character')
+        return self._lookup_stat('character', [])
 
     @property
     def additional_tags(self):
         """Any additional tags on the work."""
-        return self._lookup_stat('freeform')
+        return self._lookup_stat('freeform', [])
 
     @property
     def language(self):
         """The language in which this work is published."""
-        return self._lookup_stat('language').strip()
+        return self._lookup_stat('language', "").strip()
 
     @property
     def published(self):
@@ -200,17 +202,17 @@ class Work(object):
     @property
     def words(self):
         """The number of words in this work."""
-        return int(self._lookup_stat('words'))
+        return int(self._lookup_stat('words', 0))
 
     @property
     def comments(self):
         """The number of comments on this work."""
-        return int(self._lookup_stat('comments'))
+        return int(self._lookup_stat('comments', 0))
 
     @property
     def kudos(self):
         """The number of kudos on this work."""
-        return int(self._lookup_stat('kudos'))
+        return int(self._lookup_stat('kudos', 0))
 
     @property
     def kudos_left_by(self):
@@ -264,7 +266,7 @@ class Work(object):
     @property
     def hits(self):
         """The number of hits this work has received."""
-        return int(self._lookup_stat('hits'))
+        return int(self._lookup_stat('hits', 0))
 
     def json(self, *args, **kwargs):
         """Provide a complete representation of the work in JSON.


### PR DESCRIPTION
Checks for if any tags are empty and if so returns an appropriate default value. Currently the system produces exceptions for missing elements if you attempt to pull up relationships for a fic with none defined or such.