### PR TITLE
don't login if password is not passed to User

### DIFF
--- a/src/ao3/__init__.py
+++ b/src/ao3/__init__.py
@@ -23,7 +23,7 @@ class AO3(object):
         """
         return Work(id=id, sess=self.session)
 
-    def login(self, username, password):
+    def login(self, username, password=None):
         """Log in to the archive.
 
         This allows you to access pages that are only available while

--- a/src/ao3/users.py
+++ b/src/ao3/users.py
@@ -17,28 +17,29 @@ ReadingHistoryItem = collections.namedtuple(
 
 class User(object):
 
-    def __init__(self, username, password, sess=None):
+    def __init__(self, username, password=None, sess=None):
         self.username = username
 
         if sess == None:
             sess = requests.Session()
 
-        req = sess.get('https://archiveofourown.org')
-        soup = BeautifulSoup(req.text, features='html.parser')
+        if password != None:
+            req = sess.get('https://archiveofourown.org')
+            soup = BeautifulSoup(req.text, features='html.parser')
 
-        authenticity_token = soup.find('input', {'name': 'authenticity_token'})['value']
+            authenticity_token = soup.find('input', {'name': 'authenticity_token'})['value']
 
-        req = sess.post('https://archiveofourown.org/user_sessions', params={
-            'authenticity_token': authenticity_token,
-            'user_session[login]': username,
-            'user_session[password]': password,
-        })
+            req = sess.post('https://archiveofourown.org/user_sessions', params={
+                'authenticity_token': authenticity_token,
+                'user_session[login]': username,
+                'user_session[password]': password,
+            })
 
-        # Unfortunately AO3 doesn't use HTTP status codes to communicate
-        # results -- it's a 200 even if the login fails.
-        if 'Please try again' in req.text:
-            raise RuntimeError(
-                'Error logging in to AO3; is your password correct?')
+            # Unfortunately AO3 doesn't use HTTP status codes to communicate
+            # results -- it's a 200 even if the login fails.
+            if 'Please try again' in req.text:
+                raise RuntimeError(
+                    'Error logging in to AO3; is your password correct?')
 
         self.sess = sess
     def __repr__(self):


### PR DESCRIPTION
Since user information can be retrieved without login, there should be an option to not attempt login