### PR TITLE
Bookmarks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,9 @@ value.)
    >>> work.bookmarks
    99
 
+   >>> work.bookmark_users
+   [['user1', 'user2'], ['pseuds1', 'pseuds2']]
+   
    >>> work.hits
    43037
 

--- a/src/ao3/works.py
+++ b/src/ao3/works.py
@@ -343,7 +343,7 @@ class Work(object):
         *args and **kwargs are passed directly to `json.dumps()` from the
         standard library.
 
-        bookmark_ids is not provided 
+        bookmark_users is not provided 
         due to time it takes to go through all the bookmarks
 
         """

--- a/src/ao3/works.py
+++ b/src/ao3/works.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 import json
+import itertools
 
 from bs4 import BeautifulSoup, Tag
 import requests
@@ -23,6 +24,8 @@ class Work(object):
         # Fetch the HTML for this work
         if sess == None:
             sess = requests.Session()
+        
+        self.sess = sess
             
         req = sess.get('https://archiveofourown.org/works/%s' % self.id)
 
@@ -263,6 +266,72 @@ class Work(object):
         # bookmarked this, but for now just return the number.
         return int(self._lookup_stat('bookmarks').contents[0])
 
+    def bookmark_users(self):
+        api_url = ('https://archiveofourown.org/works/%s/bookmarks?page=%%d'
+        % self.id)
+
+        usernames = []
+        pseuds = []
+
+        num_users = 0
+        for page_no in itertools.count(start=1):
+            print("Finding page: \t" + str(page_no) + " of bookmarks. \t" + str(num_users) + " usernames found.")
+
+            req = self.sess.get(api_url % page_no)
+            soup = BeautifulSoup(req.text, features='html.parser')
+
+            # The entries are stored in a list of the form:
+            #
+            #       <ol class="bookmark index group">
+            #           <li id="work_[workid]" class="work blurb group" role="article">
+            #               ...
+            #           </li>
+            #           <li class="user short blurb group" role="article">
+            #               ...
+            #           </li>
+            #           ...
+            #
+            # name is 'username' if on default pseudonym, else 'username (pseudonym)'
+            #
+
+            ol_tag = soup.find('ol', attrs={'class': 'bookmark'})
+
+            for li_tag in ol_tag.findAll('li', attrs={'class': 'user'}):
+                num_users = num_users + 1
+
+                #               <div class="header module">
+                #                   <h5 class="byline heading">
+                #                       Bookmared by
+                #                       <a href=/users/[username]/pseuds/[pseudsname]>[name]</a>
+                #                   </h5>
+                #                   ...
+                #               </div>
+
+                h5_tag = li_tag.find('h5', attrs={'class': 'heading'})
+                link = h5_tag.find('a')
+                href = link.get('href')
+                
+                username = href[len('/users/') : href.find('/pseuds/')]
+                usernames.append(username)
+                pseud = href[href.find('/pseuds/') + len('/pseuds/'):]
+                pseuds.append(pseud)
+
+            # The pagination button at the end of the page is of the form
+            #
+            #     <li class="next" title="next"> ... </li>
+            #
+            # If there's another page of results, this contains an <a> tag
+            # pointing to the next page.  Otherwise, it contains a <span>
+            # tag with the 'disabled' class.
+            try:
+                next_button = soup.find('li', attrs={'class': 'next'})
+                if next_button.find('span', attrs={'class': 'disabled'}):
+                    break
+            except:
+                # In case of absence of "next"
+                break
+        return (usernames, pseuds)
+
     @property
     def hits(self):
         """The number of hits this work has received."""
@@ -273,6 +342,9 @@ class Work(object):
 
         *args and **kwargs are passed directly to `json.dumps()` from the
         standard library.
+
+        bookmark_ids is not provided 
+        due to time it takes to go through all the bookmarks
 
         """
         data = {

--- a/src/ao3/works.py
+++ b/src/ao3/works.py
@@ -266,6 +266,7 @@ class Work(object):
         # bookmarked this, but for now just return the number.
         return int(self._lookup_stat('bookmarks').contents[0])
 
+    @property
     def bookmark_users(self):
         api_url = ('https://archiveofourown.org/works/%s/bookmarks?page=%%d'
         % self.id)


### PR DESCRIPTION
Add bookmark_users to Work.

`Work.bookmark_users` returns a list of (list of usernames) and (list of pseudonyms) in case people needed to know both. ex: `[ [user1, user2, ,user3], [pseuds1, pseuds2, pseuds3] ]`

On additional note, it also saves session in `Work.__init__` so it can be reused when getting bookmarked users.